### PR TITLE
Small fix of numeration description

### DIFF
--- a/docs/rst/container_yml/template.rst
+++ b/docs/rst/container_yml/template.rst
@@ -43,7 +43,7 @@ and ``debug``.
     Resolving Jinja expressions to render the final ``container.yml`` is done inside the ``conductor`` container.
 
 
-There are three ways to provide variable values:
+There are four ways to provide variable values:
 
 * Role defaults
 * Passing a YAML or JSON file with the ``--vars-file`` option


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### SUMMARY
Small fix of a Monty Python's Spanish Inquisition like error:
changing "There are three ways to provide variable values" with four values below
into "There are four ways to provide variable values".